### PR TITLE
오류 수정

### DIFF
--- a/community/ForcedEviction.sql
+++ b/community/ForcedEviction.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE TRIGGER ForcedEviction
 BEGIN
     DECLARE post_status INTEGER;
     if
-        NEW.status = 'N' AND OLD.status <> 'N' then
+        NEW.status = 'N' AND OLD.status = 'Y' then
         UPDATE post
         SET current_count = current_count - 1
         WHERE id = NEW.post_id;


### PR DESCRIPTION
## 🛠️ Develop  
ForcedEviction.sql에서 if문의 조건을 NEW.status = 'N' AND OLD.status <> 'N'에서 NEW.status = 'N' AND OLD.status = 'Y'으로 바꿈
원래는 승인 상태가 'U'에서 'N'으로 업데이트된 경우에도 트리거가 작동하게끔 되어있었는데, 승인에서 거절로 업데이트 되었을 때만 현재 확정 인원수를 줄이도록 수정하였다.